### PR TITLE
Fixes new network web error in relation to far_share_hash

### DIFF
--- a/p2pool/web.py
+++ b/p2pool/web.py
@@ -292,7 +292,7 @@ def get_web_root(wb, datadir_path, bitcoind_getinfo_var, stop_event=variable.Eve
         
         return dict(
             parent='%064x' % share.previous_hash,
-            far_parent='%064x' % share.share_info['far_share_hash'],
+            far_parent='%064x' % share.share_info['far_share_hash'] if share.share_info['far_share_hash'],
             children=['%064x' % x for x in sorted(node.tracker.reverse.get(share.hash, set()), key=lambda sh: -len(node.tracker.reverse.get(sh, set())))], # sorted from most children to least children
             type_name=type(share).__name__,
             local=dict(


### PR DESCRIPTION
When a new network is created, a fresh sharechain is causing this dictionary to request data that returns none, and thus the conversion to a number with 64 digits throws an error in the CLI.