### PR TITLE
Lyra2REv3 Testnet

### DIFF
--- a/p2pool/bitcoin/networks/vertcoin.py
+++ b/p2pool/bitcoin/networks/vertcoin.py
@@ -14,7 +14,7 @@ SEGWIT_ADDRESS_VERSION=5
 RPC_PORT=5888
 RPC_CHECK=lambda bitcoind: True
 SUBSIDY_FUNC=lambda height: 50*100000000 >> (height + 1)//840000
-POW_FUNC=lambda data: pack.IntType(256).unpack(__import__('lyra2re2_hash').getPoWHash(data))
+POW_FUNC=lambda data: pack.IntType(256).unpack(__import__('lyra2re3_hash').getPoWHash(data))
 BLOCK_PERIOD=150 # s
 SYMBOL='VTC'
 CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Vertcoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Vertcoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.vertcoin'), 'vertcoin.conf')

--- a/p2pool/bitcoin/networks/vertcoin_testnet.py
+++ b/p2pool/bitcoin/networks/vertcoin_testnet.py
@@ -14,7 +14,7 @@ SEGWIT_ADDRESS_VERSION=196
 RPC_PORT=15888
 RPC_CHECK=lambda bitcoind: True
 SUBSIDY_FUNC=lambda height: 50*100000000 >> (height + 1)//840000
-POW_FUNC=lambda data: pack.IntType(256).unpack(__import__('lyra2re2_hash').getPoWHash(data))
+POW_FUNC=lambda data: pack.IntType(256).unpack(__import__('lyra2re3_hash').getPoWHash(data))
 BLOCK_PERIOD=150 # s
 SYMBOL='VTCTEST'
 CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Vertcoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Vertcoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.vertcoin'), 'vertcoin.conf')


### PR DESCRIPTION
This adds support for mining Lyra2REv3 on testnet.

Does depend on https://github.com/metalicjames/lyra2re-hash-python/pull/5 to be merged in.