### PR TITLE
Add verthash to vertcoin mainnet

### DIFF
--- a/p2pool/bitcoin/networks/vertcoin.py
+++ b/p2pool/bitcoin/networks/vertcoin.py
@@ -6,6 +6,16 @@ from twisted.internet import defer
 from .. import data, helper
 from p2pool.util import pack
 
+import verthash
+
+verthash_data = None
+if verthash_data is None:
+    with open('verthash.dat', 'rb') as f:
+        verthash_data = f.read()
+
+def verthash_hash(dat):
+    return verthash.getPoWHash(dat, verthash_data)
+
 
 P2P_PREFIX='fabfb5da'.decode('hex')
 P2P_PORT=5889
@@ -14,7 +24,7 @@ SEGWIT_ADDRESS_VERSION=5
 RPC_PORT=5888
 RPC_CHECK=lambda bitcoind: True
 SUBSIDY_FUNC=lambda height: 50*100000000 >> (height + 1)//840000
-POW_FUNC=lambda data: pack.IntType(256).unpack(__import__('lyra2re3_hash').getPoWHash(data))
+POW_FUNC=lambda data: pack.IntType(256).unpack(verthash_hash(data))
 BLOCK_PERIOD=150 # s
 SYMBOL='VTC'
 CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Vertcoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Vertcoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.vertcoin'), 'vertcoin.conf')

--- a/p2pool/networks/vertcoin.py
+++ b/p2pool/networks/vertcoin.py
@@ -16,6 +16,6 @@ WORKER_PORT=9171
 BOOTSTRAP_ADDRS='vtc.alwayshashing.com crypto.office-on-the.net pool.vtconline.org p2pool.kosmoplovci.org uk1.vtconline.org pool.boxienet.net'.split(' ')
 ANNOUNCE_CHANNEL='#p2pool-vtc'
 VERSION_CHECK=lambda v: True
-SOFTFORKS_REQUIRED = set(['nversionbips', 'csv', 'segwit'])
+SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit'])
 SEGWIT_ACTIVATION_VERSION = 16
 MINIMUM_PROTOCOL_VERSION = 1800

--- a/p2pool/networks/vertcoin2.py
+++ b/p2pool/networks/vertcoin2.py
@@ -16,6 +16,6 @@ WORKER_PORT=9181
 BOOTSTRAP_ADDRS='vtc2.alwayshashing.com pool.vtconline.org uk1.vtconline.org pool.boxienet.net'.split(' ')
 ANNOUNCE_CHANNEL='#p2pool-vtc'
 VERSION_CHECK=lambda v: True
-SOFTFORKS_REQUIRED = set(['nversionbips', 'csv', 'segwit'])
+SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit'])
 SEGWIT_ACTIVATION_VERSION = 16
 MINIMUM_PROTOCOL_VERSION = 1800


### PR DESCRIPTION
Adds Verthash support to P2Pool for Vertcoin mainnet. Requires the verthash python module: https://github.com/vertcoin-project/verthash-pospace.