### PR TITLE
Use getnewaddress rather than getaccountaddress

### DIFF
--- a/p2pool/main.py
+++ b/p2pool/main.py
@@ -137,7 +137,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             
             if address is None:
                 print '    Getting payout address from bitcoind...'
-                address = yield deferral.retry('Error getting payout address from bitcoind:', 5)(lambda: bitcoind.rpc_getaccountaddress('p2pool'))()
+                address = yield deferral.retry('Error getting payout address from bitcoind:', 5)(lambda: bitcoind.rpc_getnewaddress('p2pool', 'legacy'))()
             
             with open(address_path, 'wb') as f:
                 f.write(address)


### PR DESCRIPTION
`getaccountaddress` has been removed from recent versions of Vertcoin Core. Use `getnewaddress` instead within p2pool. This fixes a bug preventing startup of a fresh p2pool instance.