### PR TITLE
Ensure blockhash is padded to 64 chars for getblock

### DIFF
--- a/p2pool/bitcoin/height_tracker.py
+++ b/p2pool/bitcoin/height_tracker.py
@@ -95,7 +95,10 @@ def get_height_rel_highest_func(bitcoind, factory, best_block_func, net):
         @defer.inlineCallbacks
         def height_cacher(block_hash):
             try:
-                x = yield bitcoind.rpc_getblock('%x' % (block_hash,))
+                block_hash_str = '%x' % (block_hash,)
+                if len(block_hash_str) != 64:
+                    block_hash_str = '0' * (64 - len(block_hash_str)) + block_hash_str
+                x = yield bitcoind.rpc_getblock(block_hash_str)
             except jsonrpc.Error_for_code(-5): # Block not found
                 if not p2pool.DEBUG:
                     raise deferral.RetrySilentlyException()


### PR DESCRIPTION
Fixes the following bug caused by a change in the JSON RPC contract with Core:

```
2021-01-27 19:00:29.471251 Error when requesting noncached value:
2021-01-27 19:00:29.471291 > Traceback (most recent call last):
2021-01-27 19:00:29.471340 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 397, in errback
2021-01-27 19:00:29.471389 >     self._startRunCallbacks(fail)
2021-01-27 19:00:29.471427 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 464, in _startRunCallbacks
2021-01-27 19:00:29.471467 >     self._runCallbacks()
2021-01-27 19:00:29.471504 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 551, in _runCallbacks
2021-01-27 19:00:29.471545 >     current.result = callback(current.result, *args, **kw)
2021-01-27 19:00:29.471585 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1101, in gotResult
2021-01-27 19:00:29.471627 >     _inlineCallbacks(r, g, deferred)
2021-01-27 19:00:29.471664 > --- <exception caught here> ---
2021-01-27 19:00:29.471703 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
2021-01-27 19:00:29.471743 >     result = result.throwExceptionIntoGenerator(g)
2021-01-27 19:00:29.471780 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
2021-01-27 19:00:29.471829 >     return g.throw(self.type, self.value, self.tb)
2021-01-27 19:00:29.471866 >   File "/home/james/workspace/p2pool-vtc/p2pool/bitcoin/height_tracker.py", line 102, in height_cacher
2021-01-27 19:00:29.471903 >     x = yield bitcoind.rpc_getblock(block_hash_str)
2021-01-27 19:00:29.471941 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
2021-01-27 19:00:29.471979 >     result = result.throwExceptionIntoGenerator(g)
2021-01-27 19:00:29.472016 >   File "/home/james/.local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
2021-01-27 19:00:29.472053 >     return g.throw(self.type, self.value, self.tb)
2021-01-27 19:00:29.472090 >   File "/home/james/workspace/p2pool-vtc/p2pool/util/jsonrpc.py", line 133, in _http_do
2021-01-27 19:00:29.472127 >     raise Error_for_code(resp['error']['code'])(resp['error']['message'], resp['error'].get('data', None))
2021-01-27 19:00:29.472174 > p2pool.util.jsonrpc.NarrowError: -8 blockhash must be of length 64 (not 63, for '25a5c9f723fc23db05b9a297b8606b90be0ff857d51f6c5e97106a0a6eb7514')

```