### PR TITLE
Update for taproot

### DIFF
--- a/p2pool/networks/vertcoin.py
+++ b/p2pool/networks/vertcoin.py
@@ -16,6 +16,6 @@ WORKER_PORT=9171
 BOOTSTRAP_ADDRS='fr1.vtconline.org p2proxy.vertcoin.org vtc.consumableresources.com'.split(' ')
 ANNOUNCE_CHANNEL='#p2pool-vtc'
 VERSION_CHECK=lambda v: True
-SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit'])
+SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit', 'taproot'])
 SEGWIT_ACTIVATION_VERSION = 16
 MINIMUM_PROTOCOL_VERSION = 1800

--- a/p2pool/networks/vertcoin_testnet.py
+++ b/p2pool/networks/vertcoin_testnet.py
@@ -16,5 +16,5 @@ WORKER_PORT=9175
 BOOTSTRAP_ADDRS='fr1.vtconline.org'.split(' ')
 ANNOUNCE_CHANNEL='#p2pool-vtc-testnet'
 VERSION_CHECK=lambda v: True
-SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit'])
+SOFTFORKS_REQUIRED = set(['bip34', 'bip66', 'bip65', 'csv', 'segwit', 'taproot'])
 SEGWIT_ACTIVATION_VERSION = 16


### PR DESCRIPTION
Updates the SOFTFORKS_REQUIRED parameter to include the recent taproot soft fork.

Users have been running into issues since taproot was activated.