### PR TITLE
update for new RPC Call 'getdeploymentinfo() for softforks info

### DIFF
--- a/p2pool/bitcoin/helper.py
+++ b/p2pool/bitcoin/helper.py
@@ -22,12 +22,15 @@ def check(bitcoind, net):
         raise deferral.RetrySilentlyException()
     
     try:
-        blockchaininfo = yield bitcoind.rpc_getblockchaininfo()
-        softforks_supported = set(item['id'] for item in blockchaininfo.get('softforks', []))
+        deploymentinfo = yield bitcoind.rpc_getdeploymentinfo() # New RPC call for softforks in Vertcoin Core 23.0+
         try:
-            softforks_supported |= set(item['id'] for item in blockchaininfo.get('bip9_softforks', []))
+            softforks_supported = set(item['id'] for item in deploymentinfo.get('deployments', [])) # not working with Vertcoin Core < 23.0
+        except TypeError:
+            softforks_supported = set(item for item in deploymentinfo.get('deployments', [])) # fix for https://github.com/jtoomim/p2pool/issues/38
+        try:
+            softforks_supported |= set(item['id'] for item in deploymentinfo.get('bip9_softforks', []))
         except TypeError: # https://github.com/bitcoin/bitcoin/pull/7863
-            softforks_supported |= set(item for item in blockchaininfo.get('bip9_softforks', []))
+            softforks_supported |= set(item for item in deploymentinfo.get('bip9_softforks', []))
     except jsonrpc.Error_for_code(-32601): # Method not found
         softforks_supported = set()
     if getattr(net, 'SOFTFORKS_REQUIRED', set()) - softforks_supported:


### PR DESCRIPTION
This PR will allow p2pool-vtc to work with Vertcoin Core 23.0+.  However, it will break p2pool-vtc with a version < 23.0.